### PR TITLE
Fix iframe width issue on mobile device

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -7972,6 +7972,10 @@
 	  }
 	};
 
+	function registerNullComponentID() {
+	  ReactEmptyComponentRegistry.registerNullComponentID(this._rootNodeID);
+	}
+
 	var ReactEmptyComponent = function (instantiate) {
 	  this._currentElement = null;
 	  this._rootNodeID = null;
@@ -7980,7 +7984,7 @@
 	assign(ReactEmptyComponent.prototype, {
 	  construct: function (element) {},
 	  mountComponent: function (rootID, transaction, context) {
-	    ReactEmptyComponentRegistry.registerNullComponentID(rootID);
+	    transaction.getReactMountReady().enqueue(registerNullComponentID, this);
 	    this._rootNodeID = rootID;
 	    return ReactReconciler.mountComponent(this._renderedComponent, rootID, transaction, context);
 	  },
@@ -18703,7 +18707,7 @@
 
 	'use strict';
 
-	module.exports = '0.14.7';
+	module.exports = '0.14.8';
 
 /***/ },
 /* 148 */
@@ -26352,7 +26356,7 @@
 	          _react2.default.createElement(
 	            _Panel2.default,
 	            { title: 'https://react-rte.org/demo', source: 'https://react-rte.org/demo', features: 'Rich Text Buttons' },
-	            _react2.default.createElement('iframe', { src: 'https://react-rte.org/demo', height: '500px', width: '1000px', frameBorder: '0' })
+	            _react2.default.createElement('iframe', { src: 'https://react-rte.org/demo', style: { display: 'block', width: '100%', height: 500 }, frameBorder: '0' })
 	          ),
 	          _react2.default.createElement(
 	            _Panel2.default,

--- a/public/src/pages/Examples.js
+++ b/public/src/pages/Examples.js
@@ -25,32 +25,32 @@ class Examples extends Component {
        	<Panel title="Plain Text" source="https://github.com/facebook/draft-js/blob/master/examples/plaintext/plaintext.html" features="Log contents to console">
         	<PlainText />
        	</Panel>
-        <Panel title="Link" source="https://github.com/facebook/draft-js/blob/master/examples/link/link.html" features="Add a link">      
+        <Panel title="Link" source="https://github.com/facebook/draft-js/blob/master/examples/link/link.html" features="Add a link">
         	<Link />
         </Panel>
-        <Panel title="Entity" source="https://github.com/facebook/draft-js/blob/master/examples/entity/entity.html" features="Try different entities">              
+        <Panel title="Entity" source="https://github.com/facebook/draft-js/blob/master/examples/entity/entity.html" features="Try different entities">
         	<Entity />
-        </Panel> 
-        <Panel title="Color" source="https://github.com/facebook/draft-js/blob/master/examples/color/color.html" features="Color Buttons">                    
+        </Panel>
+        <Panel title="Color" source="https://github.com/facebook/draft-js/blob/master/examples/color/color.html" features="Color Buttons">
         	<Color />
         </Panel>
-        <Panel title="Rich Text" source="https://github.com/facebook/draft-js/blob/master/examples/rich/rich.html" features="Classic Rich text editor">                    
+        <Panel title="Rich Text" source="https://github.com/facebook/draft-js/blob/master/examples/rich/rich.html" features="Classic Rich text editor">
         	<Rich />
         </Panel>
-        <Panel title="TeXEditorExample" source="https://github.com/facebook/draft-js/blob/master/examples/tex" features="Click on the equation to edit; Add new equation">                    
+        <Panel title="TeXEditorExample" source="https://github.com/facebook/draft-js/blob/master/examples/tex" features="Click on the equation to edit; Add new equation">
         	<TexEditorExample />
         </Panel>
-        <Panel title="@mention #hashtag" source="https://github.com/facebook/draft-js/blob/master/examples/tweet" features="@mention and #hashtag">                    
+        <Panel title="@mention #hashtag" source="https://github.com/facebook/draft-js/blob/master/examples/tweet" features="@mention and #hashtag">
           <Tweet />
         </Panel>
-        <Panel title="DraftJS-Plugins Editor" source="https://www.draft-js-plugins.com/" features="1. @mention w/ menu 2. Stickers! 3. colorful links 4. Hashtags 5. Undo/Redo">                    
+        <Panel title="DraftJS-Plugins Editor" source="https://www.draft-js-plugins.com/" features="1. @mention w/ menu 2. Stickers! 3. colorful links 4. Hashtags 5. Undo/Redo">
           <DraftJSPluginsEditor />
         </Panel>
 
-        <Panel title="https://react-rte.org/demo" source="https://react-rte.org/demo" features="Rich Text Buttons">                    
-             <iframe src="https://react-rte.org/demo" height="500px" width="1000px" frameBorder="0"/>
+        <Panel title="https://react-rte.org/demo" source="https://react-rte.org/demo" features="Rich Text Buttons">
+             <iframe src="https://react-rte.org/demo"  style={{display: 'block', width: '100%', height: 500}} frameBorder="0"/>
         </Panel>
-        <Panel title="Facebook Notes clone" source="https://github.com/andrewcoelho/react-text-editor" features="Add images, bold, italics, numbered rows">                    
+        <Panel title="Facebook Notes clone" source="https://github.com/andrewcoelho/react-text-editor" features="Add images, bold, italics, numbered rows">
         	   Note: If you are not seeing anything, reload this app in HTTP(not HTTPS) I'm just iframing it from <a href="http://www.andrewcoelho.com/react-text-editor/" target="_blank">http://www.andrewcoelho.com/react-text-editor/</a>)
              <iframe src="http://www.andrewcoelho.com/react-text-editor/" height="1000px" width="1100px" frameBorder="0"/>
         </Panel>


### PR DESCRIPTION
This fixes an issue that looks like this:

<img width="376" alt="screenshot 2016-03-31 18 21 27" src="https://cloud.githubusercontent.com/assets/369384/14174248/6e3cb01c-f76d-11e5-898e-602817280bc7.png">

As for the extraneous changes, I only changed line 51 of `public/src/pages/Examples.js` but my editor, trying to be smart, trimmed a bunch of trailing whitespace on some other lines. I though about reverting that, but actually it might be a good idea.

As for the changes in `public/bundle.js` I just ran `npm run build` and your build system did all that. Let me know if you want me to revert any of those.

Thanks!
